### PR TITLE
Enforcer: Sound Updates

### DIFF
--- a/Classes/UT3Enforcer.uc
+++ b/Classes/UT3Enforcer.uc
@@ -484,7 +484,10 @@ defaultproperties
     FireModeClass(0)=UT3EnforcerFire
     FireModeClass(1)=UT3EnforcerAltFire
     PickupClass=class'UT3EnforcerPickup'
-    SelectSound=Sound'UT3Weapons.Enforcer.EnforcerTakeOut'
+    ReloadSound=Sound'UT3A_Weapon_Enforcer.ReloadComposite.ReloadCompositeCue'
+    SelectSound=Sound'UT3A_Weapon_Enforcer.WeaponEquip.EquipCue'
+    PutDownSound=Sound'UT3A_Weapon_Enforcer.WeaponUnEquip.UnEquipCue'
+    TransientSoundVolume=0.8
 
     CustomCrosshairTextureName="UT3HUD.Crosshairs.UT3CrosshairEnforcer"
     CustomCrosshairColor=(R=255,G=255,B=255,A=255)
@@ -520,11 +523,10 @@ defaultproperties
     SmallViewOffset=(X=60.0,Y=12.0,Z=-13.0)
     PlayerViewPivot=(Pitch=-500,Yaw=750,Roll=0)
     AttachmentClass=class'UT3EnforcerAttachment'
-    ReloadSound=Sound'UT3Weapons2.Enforcer.EnforcerReload'
     bAlreadyLoaded=False
     AkimboDelay=2.0
     AkimboTime=1.3636
     HighDetailOverlay=None
     UDamageOverlay=Material'UT3Pickups.Udamage.M_UDamage_Overlay_S'
-    PutDownSound=Sound'UT3Weapons2.Enforcer.A_Weapon_Enforcer_Lower01'
+    
 }

--- a/Classes/UT3Enforcer.uc
+++ b/Classes/UT3Enforcer.uc
@@ -484,9 +484,9 @@ defaultproperties
     FireModeClass(0)=UT3EnforcerFire
     FireModeClass(1)=UT3EnforcerAltFire
     PickupClass=class'UT3EnforcerPickup'
-    ReloadSound=Sound'UT3A_Weapon_Enforcer.ReloadComposite.ReloadCompositeCue'
-    SelectSound=Sound'UT3A_Weapon_Enforcer.WeaponEquip.EquipCue'
-    PutDownSound=Sound'UT3A_Weapon_Enforcer.WeaponUnEquip.UnEquipCue'
+    ReloadSound=Sound'UT3A_Weapon_Enforcer.UT3EnforcerReloadComposite.UT3EnforcerReloadCompositeCue'
+    SelectSound=Sound'UT3A_Weapon_Enforcer.UT3EnforcerRaise.UT3EnforcerRaiseCue'
+    PutDownSound=Sound'UT3A_Weapon_Enforcer.UT3EnforcerLower.UT3EnforcerLowerCue'
     TransientSoundVolume=0.8
 
     CustomCrosshairTextureName="UT3HUD.Crosshairs.UT3CrosshairEnforcer"

--- a/Classes/UT3EnforcerFire.uc
+++ b/Classes/UT3EnforcerFire.uc
@@ -80,8 +80,8 @@ defaultproperties
     DamageMin=20
     DamageMax=20
     //bPawnRapidFireAnim=false
-    FireSound=Sound'UT3A_Weapon_Enforcer.Fire.FireCue'
-    TransientSoundVolume=1.2
+    FireSound=Sound'UT3A_Weapon_Enforcer.UT3EnforcerFire.UT3EnforcerFireCue'
+    TransientSoundVolume=0.8
     Spread=0.030
     FireRate=0.36
     BotRefireRate=0.36

--- a/Classes/UT3EnforcerFire.uc
+++ b/Classes/UT3EnforcerFire.uc
@@ -80,7 +80,8 @@ defaultproperties
     DamageMin=20
     DamageMax=20
     //bPawnRapidFireAnim=false
-    FireSound=Sound'UT3Weapons.Enforcer.EnforcerPrimary2'
+    FireSound=Sound'UT3A_Weapon_Enforcer.Fire.FireCue'
+    TransientSoundVolume=1.2
     Spread=0.030
     FireRate=0.36
     BotRefireRate=0.36


### PR DESCRIPTION
The Enforcer has a lot more that isn't currently in use, namely impact sounds for a lot of different surface types including flesh

I'm beginning to question if these are going to be acceptable or not, it's almost like in UT3 they forgot to use the cue version of this which has a lot more boom to it than the normal shots, and I can say this is also true with the Stinger so I think what would be a good idea is to make a video of both the new cue sounds and then a video for the old sounds to compare since you don't have access to UT3 or UT2004 right now and I'm apparently the only one working on the weapons portion.

For that matter I could also do a UT3 video too.

EDIT - I was hearing impact metal, firing at the sky it does sound closer to the cues now.